### PR TITLE
Prepare 1.0.0 release

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -31,6 +31,8 @@
     "Pcheckstyle",
     "peaceiris",
     "Pjacoco",
+    "Prelease",
+    "Pspotbugs",
     "reinit",
     "Reinitializer",
     "Retryable",
@@ -40,7 +42,8 @@
     "stackoverflow",
     "SZDIAGNOSTIC",
     "temurin",
-    "USERPROFILE"
+    "USERPROFILE",
+    "xerial"
   ],
   "ignorePaths": [".git/**", "**/test/**", "Makefile", "pom.xml"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - 2026-05-14
+
+### Changes in version 1.0.0
+
+- Initial stable release.
+- Raised the minimum required `com.senzing:sz-sdk` version from `4.1.0`
+  to `4.3.0`, which relocates `GenerateTestJVMScript` from
+  `com.senzing.test` (test scope) to `com.senzing.sdk.core` (main
+  scope); the test-wrapper generation in `pom.xml` was updated to match.
+- Upgraded `com.senzing:senzing-commons` (test scope) from `4.0.0-beta.3.0`
+  to `4.0.0`.
+- Upgraded `org.xerial:sqlite-jdbc` (test scope) from `3.51.3.0` to
+  `3.53.0.0`.
+
 ## [0.5.1] - 2026-02-25
 
 ### Fixed in version 0.5.1

--- a/README.md
+++ b/README.md
@@ -1,9 +1,219 @@
 # sz-sdk-java-auto
 
-If you are beginning your journey with [Senzing],
-please start with [Senzing Quick Start guides].
+The **Senzing Automatic Core SDK for Java** extends the
+[Senzing Core SDK for Java](https://github.com/senzing-garage/sz-sdk-java)
+with automatic handling features that make the SDK well-suited for
+long-running, multi-threaded, server-side applications.
 
-You are in the [Senzing Garage] where projects are "tinkered" on.
-Although this GitHub repository may help you understand an approach to using Senzing,
-it's not considered to be "production ready" and is not considered to be part of the Senzing product.
-Heck, it may not even be appropriate for your application of Senzing!
+> If you are beginning your journey with [Senzing], please start with the
+> [Senzing Quick Start guides].
+>
+> You are in the [Senzing Garage] where projects are "tinkered" on.
+> Although this GitHub repository may help you understand an approach to
+> using Senzing, it's not considered to be "production ready" and is not
+> considered to be part of the Senzing product. It may not even be
+> appropriate for your application of Senzing.
+
+## Features
+
+`SzAutoCoreEnvironment` is a drop-in replacement for `SzCoreEnvironment`
+that adds the following capabilities:
+
+- **Automatic basic retry** for any Senzing Core SDK method that fails
+  with an `SzRetryableException`. The method is retried up to a
+  configurable maximum, with an increasing delay between attempts.
+
+- **Automatic configuration refresh** keeps the active configuration in
+  sync with the current default configuration. Three modes are
+  available:
+  - **Disabled** — no automatic refresh.
+  - **Reactive** — on-demand refresh when a method annotated with
+    `@SzConfigRetryable` fails; if the configuration actually changed,
+    the method is automatically retried.
+  - **Proactive** — a background thread periodically compares the
+    active and default configuration IDs and reinitializes when they
+    differ. Reactive refresh is also performed in this mode.
+
+- **Isolated thread pool** that confines all Senzing Core SDK operations
+  to a fixed set of worker threads, allowing the SDK's thread-local
+  resources to be reused across operations while preventing excessive
+  memory growth from too many threads.
+
+- **`ExecutorService`-like interface** (`submitTask(...)`) for running
+  user code on the same thread pool as the SDK operations, avoiding
+  unnecessary context switching when multiple SDK calls are made from
+  the same task.
+
+## Requirements
+
+- **Java 17** or later.
+- A working Senzing installation with native libraries (required at
+  runtime by the underlying Senzing Core SDK).
+
+## Maven Dependency
+
+`sz-sdk-java-auto` is published to Maven Central:
+
+```xml
+<dependency>
+  <groupId>com.senzing</groupId>
+  <artifactId>sz-sdk-auto</artifactId>
+  <version>1.0.0</version>
+</dependency>
+```
+
+This artifact transitively depends on the Senzing Core SDK for Java
+(`com.senzing:sz-sdk`), so you do not need to declare it separately.
+
+## Usage
+
+### Creating an `SzAutoCoreEnvironment`
+
+Use `SzAutoCoreEnvironment.newAutoBuilder()` (or
+`new SzAutoCoreEnvironment.Builder()`) to configure and create an
+instance. The builder inherits all of the standard `SzCoreEnvironment`
+configuration (settings, instance name, verbose logging, etc.) and adds
+three additional options.
+
+```java
+import java.time.Duration;
+import com.senzing.sdk.SzEngine;
+import com.senzing.sdk.core.auto.SzAutoCoreEnvironment;
+
+String settings = "{ \"PIPELINE\": { ... }, \"SQL\": { ... } }";
+
+try (SzAutoCoreEnvironment env = SzAutoCoreEnvironment.newAutoBuilder()
+        .instanceName("my-app")
+        .settings(settings)
+        .verboseLogging(false)
+        .maxBasicRetries(2)                         // default is 2
+        .configRefreshPeriod(Duration.ofMinutes(1)) // proactive refresh
+        .concurrency(SzAutoCoreEnvironment.RECOMMENDED_CONCURRENCY)
+        .build())
+{
+    SzEngine engine = env.getEngine();
+    // ... use the engine, configManager, diagnostic, product, etc.
+}
+```
+
+Only **one** active `SzCoreEnvironment` instance (including any
+`SzAutoCoreEnvironment`) may exist in a JVM process at a time. The
+existing instance must be destroyed before a new one can be created.
+
+### Configuration Refresh
+
+The `configRefreshPeriod(Duration)` builder method controls the refresh
+mode:
+
+| Value | Mode | Behavior |
+|-------|------|----------|
+| `null` (`DISABLED_CONFIG_REFRESH`) | Disabled | No automatic refresh; `@SzConfigRetryable` methods are not retried. |
+| `Duration.ZERO` (`REACTIVE_CONFIG_REFRESH`) | Reactive | Refresh on-demand when a `@SzConfigRetryable` method fails; retry if the configuration actually changed. |
+| Positive `Duration` | Proactive | Background thread refreshes every N seconds. Reactive refresh also occurs on failures. |
+
+**Note:** Configuration refresh cannot be combined with an explicit
+`configId(Long)`. The builder will throw `IllegalStateException` if
+both are set.
+
+### Thread Pool
+
+The `concurrency(Integer)` builder method controls the internal thread
+pool used to execute SDK operations:
+
+| Value | Behavior |
+|-------|----------|
+| `null` (`DISABLED_CONCURRENCY`) | Thread pool disabled; SDK operations run in the calling thread. |
+| `0` (`RECOMMENDED_CONCURRENCY`) | Pool sized to `Runtime.availableProcessors()`. |
+| Positive integer | Pool sized to the specified value. |
+
+When the thread pool is enabled, you can submit your own tasks to run
+on the same pool — useful when a task makes multiple SDK calls and you
+want to avoid context switching between them:
+
+```java
+Future<String> result = env.submitTask(() -> {
+    SzEngine engine = env.getEngine();
+    return engine.getEntityByRecordId("CUSTOMERS", "1001", flags);
+});
+```
+
+### Basic Retry
+
+`maxBasicRetries(int)` sets the maximum number of times any SDK method
+will be retried when it fails with `SzRetryableException`. The default
+is `2`. Each subsequent retry uses an increasing delay to allow the
+underlying condition to resolve.
+
+## Building from Source
+
+### Prerequisites
+
+1. **Java 17** or later.
+2. **Apache Maven**.
+3. **Senzing native libraries** installed locally (required for running
+   the test suite).
+4. The `sz-sdk-java` submodule, which provides shared test
+   infrastructure and the parent `SzCoreEnvironment` class:
+
+   ```sh
+   git submodule update --init --recursive
+   ```
+
+### Environment Variables
+
+The tests need to know where the Senzing installation lives:
+
+- `SENZING_PATH` — path to the Senzing installation.
+- `SENZING_DEV_LIBRARY_PATH` — path to the Senzing development
+  libraries.
+
+### Common Commands
+
+```sh
+# Full clean build, including tests
+mvn clean install
+
+# Compile and package without running tests
+mvn clean install -DskipTests
+
+# Run the test suite (requires Senzing native libraries)
+mvn test
+
+# Run a single test class
+mvn test -Dtest=EngineBasicsTest
+
+# Run a single test method
+mvn test -Dtest=EngineBasicsTest#someMethod
+
+# Run with code coverage (JaCoCo)
+mvn test -Pjacoco
+
+# Run Checkstyle
+mvn validate -Pcheckstyle
+
+# Run SpotBugs (with FindSecBugs)
+mvn validate -Pspotbugs
+
+# Release build with GPG signing
+mvn clean install -Prelease
+```
+
+## Documentation
+
+API documentation (Javadoc) is published alongside each release on
+Maven Central. The Javadoc for `sz-sdk-java-auto` links against the
+Javadoc for the underlying [Senzing Core SDK for Java].
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for license-agreement details
+and the pull request workflow.
+
+## License
+
+Licensed under the [Apache License, Version 2.0](LICENSE).
+
+[Senzing]: https://senzing.com
+[Senzing Quick Start guides]: https://docs.senzing.com/quickstart/
+[Senzing Garage]: https://github.com/senzing-garage
+[Senzing Core SDK for Java]: https://github.com/senzing-garage/sz-sdk-java

--- a/pom.xml
+++ b/pom.xml
@@ -4,10 +4,10 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-auto</artifactId>
   <packaging>jar</packaging>
-  <version>0.5.1</version>
+  <version>1.0.0</version>
   <name>Senzing Java Automatic Core SDK</name>
   <description>
-    The Senzing Automatic Core SDK for Java provides enhancements over the 
+    The Senzing Automatic Core SDK for Java provides enhancements over the
     Senzing Core SDK for Java by providing automatic handling of several
     functions that are useful when used in a long-running multi-threaded
     server-side process.
@@ -49,17 +49,17 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
   </properties>
-  
+
   <dependencies>
     <dependency>
-        <groupId>com.senzing</groupId>
-        <artifactId>sz-sdk</artifactId>
-        <version>[4.1.0,4.99999999.99999999]</version>
+      <groupId>com.senzing</groupId>
+      <artifactId>sz-sdk</artifactId>
+      <version>[4.3.0,4.99999999.99999999]</version>
     </dependency>
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>4.0.0-beta.3.0</version>
+      <version>4.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -100,27 +100,27 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.51.3.0</version>
+      <version>3.53.0.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
-       <groupId>org.slf4j</groupId>
-       <artifactId>slf4j-api</artifactId>
-       <version>2.0.17</version>
-       <scope>test</scope>
-   </dependency>
-   <dependency>
-       <groupId>org.slf4j</groupId>
-       <artifactId>slf4j-simple</artifactId>
-       <version>2.0.17</version>
-       <scope>test</scope>
-  </dependency>
-  <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>2.0.17</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>uk.org.webcompere</groupId>
       <artifactId>system-stubs-jupiter</artifactId>
       <version>2.1.8</version>
       <scope>test</scope>
-  </dependency>
+    </dependency>
   </dependencies>
   <build>
     <finalName>${project.artifactId}</finalName>
@@ -144,7 +144,7 @@
               <goal>java</goal>
             </goals>
             <configuration>
-              <mainClass>com.senzing.test.GenerateTestJVMScript</mainClass>
+              <mainClass>com.senzing.sdk.core.GenerateTestJVMScript</mainClass>
               <classpathScope>test</classpathScope>
               <arguments>
                 <argument>${project.build.directory}/java-wrapper/bin/java-wrapper.bat</argument>


### PR DESCRIPTION
Bump project version to 1.0.0 for the initial stable release and align with the relocated test-wrapper class in sz-sdk 4.3.0.

- pom.xml: version 0.5.1 -> 1.0.0; raise sz-sdk minimum from 4.1.0 to 4.3.0 (GenerateTestJVMScript moved from com.senzing.test to com.senzing.sdk.core, now part of the sz-sdk main jar); update the exec-maven-plugin mainClass accordingly; bump senzing-commons from 4.0.0-beta.3.0 to 4.0.0 and sqlite-jdbc from 3.51.3.0 to 3.53.0.0 (both test scope).
- CHANGELOG.md: add 1.0.0 entry documenting the version bump, sz-sdk minimum bump, and test-scope dependency upgrades.
- README.md: replace stub with full project documentation covering features, requirements, Maven coordinates, builder usage, refresh modes, thread-pool configuration, build/test commands, and the Senzing Garage disclaimer.
- sz-sdk-java: advance submodule pointer to the 4.3.0 SDK revision.
