### PR TITLE
Prepare 1.0.1 release

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Git Policy
 
-**Do not commit code.** Never run `git commit`, `git push`, or any command that creates or modifies commits. Instead, offer to generate a commit message so the user can commit manually.
+Claude may edit files, create branches, commit, and push changes directly using
+clear, detailed commit messages. Prefer working on a feature branch rather than
+committing directly to `main`. Do not merge pull requests without confirmation.
 
 ## Project Overview
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 [markdownlint](https://dlaa.me/markdownlint/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-06-17
+
+### Changes in version 1.0.1
+
+- Upgraded `com.senzing:senzing-commons` (test scope) from `4.0.0` to `4.0.1`.
+- Upgraded `org.junit.jupiter:junit-jupiter` (test scope) from `6.0.3` to `6.1.0`.
+- Upgraded `org.slf4j:slf4j-api` (test scope) from `2.0.17` to `2.0.18`.
+- Upgraded `org.slf4j:slf4j-simple` (test scope) from `2.0.17` to `2.0.18`.
+- Upgraded `org.xerial:sqlite-jdbc` (test scope) from `3.53.0.0` to `3.53.1.0`.
+- Upgraded `org.apache.maven.plugins:maven-enforcer-plugin` (build) from `3.6.2`
+  to `3.6.3`.
+
 ## [1.0.0] - 2026-05-14
 
 ### Changes in version 1.0.0

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.senzing</groupId>
   <artifactId>sz-sdk-auto</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>Senzing Java Automatic Core SDK</name>
   <description>
     The Senzing Automatic Core SDK for Java provides enhancements over the
@@ -59,7 +59,7 @@
     <dependency>
       <groupId>com.senzing</groupId>
       <artifactId>senzing-commons</artifactId>
-      <version>4.0.0</version>
+      <version>4.0.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>6.0.3</version>
+      <version>6.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -100,19 +100,19 @@
     <dependency>
       <groupId>org.xerial</groupId>
       <artifactId>sqlite-jdbc</artifactId>
-      <version>3.53.0.0</version>
+      <version>3.53.1.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>2.0.17</version>
+      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>2.0.17</version>
+      <version>2.0.18</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -197,7 +197,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.6.2</version>
+        <version>3.6.3</version>
         <executions>
           <execution>
             <id>enforce</id>


### PR DESCRIPTION
## Summary

Bundles the currently-pending Dependabot dependency updates together with a
`senzing-commons` bump into a single **1.0.1** release. Bumps the project
version `1.0.0` → `1.0.1`.

### Dependency changes (all `pom.xml` build/test scope)

| Dependency | From → To | Scope | Dependabot |
|------------|-----------|-------|-----------|
| `com.senzing:senzing-commons` | 4.0.0 → 4.0.1 | test | — |
| `org.junit.jupiter:junit-jupiter` | 6.0.3 → 6.1.0 | test | #113 |
| `org.slf4j:slf4j-api` | 2.0.17 → 2.0.18 | test | #108 |
| `org.slf4j:slf4j-simple` | 2.0.17 → 2.0.18 | test | #109 |
| `org.xerial:sqlite-jdbc` | 3.53.0.0 → 3.53.1.0 | test | #106 |
| `org.apache.maven.plugins:maven-enforcer-plugin` | 3.6.2 → 3.6.3 | build | #112 |

Applying these directly should let Dependabot auto-close #106, #108, #109,
#112, and #113.

### Other changes

- `CHANGELOG.md`: new `[1.0.1] - 2026-06-17` section documenting the
  outward-facing build/test dependency changes.
- `.claude/CLAUDE.md`: updated the Git Policy to reflect the maintainer's new
  workflow (Claude may commit/push directly on feature branches; PR merges
  still require confirmation).

### Verification

- `mvn validate` passes (enforcer 3.6.3, `RequireUpperBoundDeps` satisfied).
- `mvn dependency:resolve` resolves all six versions, including
  `senzing-commons:4.0.1` (now published to Maven Central).

---

Resolves #113
Resolves #108
Resolves #109
Resolves #106
Resolves #112